### PR TITLE
TEST: Afficher information d'un vitrail

### DIFF
--- a/features/afficher_information_84.feature
+++ b/features/afficher_information_84.feature
@@ -5,6 +5,7 @@ L'utilisateur affiche les informations associées à un vitrail (Lieu, Date, Tec
 
 Scénario: Affichage des information d'un vitrail
 
-Étant donné que Bob, doctorant, souhaite connaitre les informations associées à un vitrail
-Quand il clique sur un vitrail
+Étant donné que je suis "doctorant"
+Et que je suis sur la page "/"
+Quand je clique sur un vitrail
 Alors la page du vitrail s'ouvre avec sa photo, des informations concernant le vitrail (Lieu, Photographe, Date, Artiste, etc ...) et les commentaires associés à celui-ci.

--- a/features/step_definitions/find_steps.rb
+++ b/features/step_definitions/find_steps.rb
@@ -187,6 +187,27 @@ Alors(/^une page s'ouvre avec la liste des contributions du membre$/) do
   pending # Write code here that turns the phrase above into concrete actions
 end
 
+Étantdonnéque(/^je suis "([^"]*)"$/) do |arg1|
+  # TODO connection
+end
+
+Étantdonnéque(/^je suis sur la page "([^"]*)"$/) do |arg1|
+  visit arg1
+end
+
+Quand(/^je clique sur un vitrail$/) do
+  all('a[href*="/item/"]', {
+    :minimum => 1,
+    :wait => 10
+  }).first.click
+end
+
+Alors(/^la page du vitrail s'ouvre avec sa photo, des informations concernant le vitrail \(Lieu, Photographe, Date, Artiste, etc \.\.\.\) et les commentaires associés à celui\-ci\.$/) do
+  find(".Description")
+  find(".Subject")
+  find(".Disclaimer")
+  find(".Sources")
+end
 
 Etantdonnéque(/^Kevin veut ajouter un commentaire sur un vitrail$/) do
   pending # Write code here that turns the phrase above into concrete actions


### PR DESCRIPTION
Le clic sur un vitrail est assez long à cause du grand nombre de vitraux dans la liste.

Pour accélérer les tests :
Corpora.js => _fetchItems => this.setState({items:items **.slice(0, 30)** .sort(by('name'))});